### PR TITLE
[BE] 상품 수정 API 구현

### DIFF
--- a/be/src/main/java/team05a/secondhand/errors/exception/ProductNotFoundException.java
+++ b/be/src/main/java/team05a/secondhand/errors/exception/ProductNotFoundException.java
@@ -1,0 +1,10 @@
+package team05a.secondhand.errors.exception;
+
+public class ProductNotFoundException extends RuntimeException {
+
+	private static final String MESSAGE = "상품을 찾을 수 없습니다.";
+
+	public ProductNotFoundException() {
+		super(MESSAGE);
+	}
+}

--- a/be/src/main/java/team05a/secondhand/errors/exception/UnauthorizedProductModificationException.java
+++ b/be/src/main/java/team05a/secondhand/errors/exception/UnauthorizedProductModificationException.java
@@ -1,0 +1,10 @@
+package team05a.secondhand.errors.exception;
+
+public class UnauthorizedProductModificationException extends RuntimeException {
+
+	private static final String MESSAGE = "접근 권한이 없는 상품입니다.";
+
+	public UnauthorizedProductModificationException() {
+		super(MESSAGE);
+	}
+}

--- a/be/src/main/java/team05a/secondhand/errors/handler/ProductExceptionHandler.java
+++ b/be/src/main/java/team05a/secondhand/errors/handler/ProductExceptionHandler.java
@@ -1,0 +1,34 @@
+package team05a.secondhand.errors.handler;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import lombok.extern.slf4j.Slf4j;
+import team05a.secondhand.errors.ErrorResponse;
+import team05a.secondhand.errors.exception.ProductNotFoundException;
+import team05a.secondhand.errors.exception.UnauthorizedProductModificationException;
+
+@Slf4j
+@RestControllerAdvice
+public class ProductExceptionHandler {
+
+	@ExceptionHandler(ProductNotFoundException.class)
+	public ResponseEntity<ErrorResponse> handleProductNotFoundException(ProductNotFoundException e) {
+		log.warn("ProductNotFoundException handling : {}", e.toString());
+
+		ErrorResponse response = ErrorResponse.from(e.getMessage());
+		return ResponseEntity.status(response.getStatus())
+			.body(response);
+	}
+
+	@ExceptionHandler(UnauthorizedProductModificationException.class)
+	public ResponseEntity<ErrorResponse> handleUnauthorizedProductModificationException(
+		UnauthorizedProductModificationException e) {
+		log.warn("UnauthorizedProductModificationException handling : {}", e.toString());
+
+		ErrorResponse response = ErrorResponse.from(e.getMessage());
+		return ResponseEntity.status(response.getStatus())
+			.body(response);
+	}
+}

--- a/be/src/main/java/team05a/secondhand/image/repository/ImageRepository.java
+++ b/be/src/main/java/team05a/secondhand/image/repository/ImageRepository.java
@@ -3,6 +3,11 @@ package team05a.secondhand.image.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import team05a.secondhand.image.data.entity.ProductImage;
+import team05a.secondhand.product.data.entity.Product;
 
 public interface ImageRepository extends JpaRepository<ProductImage, Long> {
+
+	Long countByProductId(Long productId);
+
+	ProductImage findFirstByProduct(Product product);
 }

--- a/be/src/main/java/team05a/secondhand/image/service/ImageService.java
+++ b/be/src/main/java/team05a/secondhand/image/service/ImageService.java
@@ -3,6 +3,7 @@ package team05a.secondhand.image.service;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -73,5 +74,26 @@ public class ImageService {
 				.build())
 			.collect(Collectors.toList());
 		return imageRepository.saveAll(productImages);
+	}
+
+	public void deleteAllBy(List<Long> deletedImageIds) {
+		if (!deletedImageIds.isEmpty()) {
+			imageRepository.deleteAllByIdInBatch(deletedImageIds);
+		}
+	}
+
+	public Long count(Long productId) {
+		return imageRepository.countByProductId(productId);
+	}
+
+	public List<String> uploadNew(Long imageCount, List<MultipartFile> newImages) {
+		if ((newImages == null && imageCount == 0) || (imageCount + Objects.requireNonNull(newImages).size()) > 10) {
+			throw new ImageCountOutOfRangeException();
+		}
+		return upload(newImages);
+	}
+
+	public String findThumbnail(Product product) {
+		return imageRepository.findFirstByProduct(product).getImageUrl();
 	}
 }

--- a/be/src/main/java/team05a/secondhand/image/service/ImageService.java
+++ b/be/src/main/java/team05a/secondhand/image/service/ImageService.java
@@ -82,7 +82,7 @@ public class ImageService {
 		}
 	}
 
-	public Long count(Long productId) {
+	public Long countImagesBy(Long productId) {
 		return imageRepository.countByProductId(productId);
 	}
 

--- a/be/src/main/java/team05a/secondhand/product/controller/ProductController.java
+++ b/be/src/main/java/team05a/secondhand/product/controller/ProductController.java
@@ -1,36 +1,44 @@
 package team05a.secondhand.product.controller;
 
-import java.util.List;
-
 import javax.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 import team05a.secondhand.image.service.ImageService;
 import team05a.secondhand.member.resolver.MemberId;
 import team05a.secondhand.product.data.dto.ProductCreateRequest;
-import team05a.secondhand.product.data.dto.ProductCreateResponse;
-import team05a.secondhand.product.data.entity.Product;
+import team05a.secondhand.product.data.dto.ProductIdResponse;
+import team05a.secondhand.product.data.dto.ProductUpdateRequest;
 import team05a.secondhand.product.service.ProductService;
 
 @RequiredArgsConstructor
 @RestController
+@RequestMapping("/api/products")
 public class ProductController {
 
 	private final ProductService productService;
 	private final ImageService imageService;
 
-	@PostMapping("/api/products")
-	public ResponseEntity<ProductCreateResponse> create(
+	@PostMapping
+	public ResponseEntity<ProductIdResponse> create(
 		@ModelAttribute @Valid ProductCreateRequest productCreateRequest, @MemberId Long memberId) {
-		List<String> imageUrls = imageService.upload(productCreateRequest.getImages());
-		Product product = productService.create(productCreateRequest, memberId, imageUrls);
-		imageService.create(product, imageUrls);
+		ProductIdResponse productIdResponse = productService.create(productCreateRequest, memberId);
 		return ResponseEntity.ok()
-			.body(ProductCreateResponse.from(product.getId()));
+			.body(productIdResponse);
+	}
+
+	@PatchMapping("/{productId}")
+	public ResponseEntity<ProductIdResponse> update(@ModelAttribute @Valid ProductUpdateRequest productUpdateRequest,
+		@PathVariable Long productId, @MemberId Long memberId) {
+		ProductIdResponse productIdResponse = productService.update(productUpdateRequest, productId, memberId);
+		return ResponseEntity.ok()
+			.body(productIdResponse);
 	}
 }

--- a/be/src/main/java/team05a/secondhand/product/data/dto/ProductIdResponse.java
+++ b/be/src/main/java/team05a/secondhand/product/data/dto/ProductIdResponse.java
@@ -4,16 +4,16 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-public class ProductCreateResponse {
+public class ProductIdResponse {
 
 	private final Long productId;
 
 	@Builder
-	private ProductCreateResponse(Long productId) {
+	private ProductIdResponse(Long productId) {
 		this.productId = productId;
 	}
 
-	public static ProductCreateResponse from(Long id) {
-		return new ProductCreateResponse(id);
+	public static ProductIdResponse from(Long id) {
+		return new ProductIdResponse(id);
 	}
 }

--- a/be/src/main/java/team05a/secondhand/product/data/dto/ProductUpdateRequest.java
+++ b/be/src/main/java/team05a/secondhand/product/data/dto/ProductUpdateRequest.java
@@ -1,0 +1,57 @@
+package team05a.secondhand.product.data.dto;
+
+import java.util.List;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import lombok.Builder;
+import lombok.Getter;
+import team05a.secondhand.address.data.entity.Address;
+import team05a.secondhand.category.data.entity.Category;
+import team05a.secondhand.member.data.entity.Member;
+import team05a.secondhand.product.data.entity.Product;
+import team05a.secondhand.status.data.entity.Status;
+
+@Getter
+public class ProductUpdateRequest {
+
+	private final Long categoryId;
+	private final Long addressId;
+	@NotBlank(message = "제목은 필수입니다.")
+	@Size(min = 1, max = 50, message = "제목은 1글자 이상, 50글자 이하여야 합니다.")
+	private final String title;
+	@NotBlank(message = "내용은 필수입니다.")
+	@Size(min = 1, max = 10000, message = "내용은 1글자 이상, 10000글자 이하여야 합니다.")
+	private final String content;
+	private final String price;
+	private final List<Long> deletedImageIds;
+	private final List<MultipartFile> newImages;
+
+	@Builder
+	private ProductUpdateRequest(Long categoryId, Long addressId, String title, String content, String price,
+		List<Long> deletedImageIds, List<MultipartFile> newImages) {
+		this.categoryId = categoryId;
+		this.addressId = addressId;
+		this.title = title;
+		this.content = content;
+		this.price = price;
+		this.deletedImageIds = deletedImageIds;
+		this.newImages = newImages;
+	}
+
+	public Product toEntity(Member member, Category category, Address address, Status status, String thumbnailUrl) {
+		return Product.builder()
+			.member(member)
+			.category(category)
+			.address(address)
+			.status(status)
+			.title(title)
+			.content(content)
+			.price(price)
+			.thumbnailUrl(thumbnailUrl)
+			.build();
+	}
+}

--- a/be/src/main/java/team05a/secondhand/product/data/entity/Product.java
+++ b/be/src/main/java/team05a/secondhand/product/data/entity/Product.java
@@ -27,6 +27,7 @@ import team05a.secondhand.address.data.entity.Address;
 import team05a.secondhand.category.data.entity.Category;
 import team05a.secondhand.image.data.entity.ProductImage;
 import team05a.secondhand.member.data.entity.Member;
+import team05a.secondhand.product.data.dto.ProductUpdateRequest;
 import team05a.secondhand.status.data.entity.Status;
 
 @Getter
@@ -85,5 +86,16 @@ public class Product {
 			return null;
 		}
 		return String.valueOf(Integer.parseInt(price));
+	}
+
+	public Product modify(ProductUpdateRequest productUpdateRequest, Category category, Address address,
+		String thumbnailUrl) {
+		this.category = category;
+		this.address = address;
+		this.title = productUpdateRequest.getTitle();
+		this.content = productUpdateRequest.getContent();
+		this.price = validPrice(productUpdateRequest.getPrice());
+		this.thumbnailUrl = thumbnailUrl;
+		return this;
 	}
 }

--- a/be/src/main/java/team05a/secondhand/product/repository/ProductRepository.java
+++ b/be/src/main/java/team05a/secondhand/product/repository/ProductRepository.java
@@ -2,7 +2,10 @@ package team05a.secondhand.product.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import team05a.secondhand.member.data.entity.Member;
 import team05a.secondhand.product.data.entity.Product;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
+
+	boolean existsByIdAndMember(Long productId, Member member);
 }

--- a/be/src/main/java/team05a/secondhand/product/service/ProductService.java
+++ b/be/src/main/java/team05a/secondhand/product/service/ProductService.java
@@ -60,7 +60,7 @@ public class ProductService {
 	public ProductIdResponse update(ProductUpdateRequest productUpdateRequest, Long productId, Long memberId) {
 		validateProductSeller(productId, memberId);
 		imageService.deleteAllBy(productUpdateRequest.getDeletedImageIds());
-		Long imageCount = imageService.count(productId);
+		Long imageCount = imageService.countImagesBy(productId);
 		List<String> newImageUrls = imageService.uploadNew(imageCount, productUpdateRequest.getNewImages());
 		String thumbnailUrl = getThumbnailUrl(imageCount, newImageUrls);
 		Product updateProduct = updateProduct(productUpdateRequest, productId, thumbnailUrl);
@@ -86,18 +86,14 @@ public class ProductService {
 	}
 
 	private void validateProductSeller(Long productId, Long memberId) {
-		existProduct(productId);
-		Member member = existMember(memberId);
+		checkProduct(productId);
+		Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
 		if (!productRepository.existsByIdAndMember(productId, member)) {
 			throw new UnauthorizedProductModificationException();
 		}
 	}
 
-	private Member existMember(Long memberId) {
-		return memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
-	}
-
-	private void existProduct(Long productId) {
+	private void checkProduct(Long productId) {
 		if (!productRepository.existsById(productId)) {
 			throw new ProductNotFoundException();
 		}

--- a/be/src/main/java/team05a/secondhand/product/service/ProductService.java
+++ b/be/src/main/java/team05a/secondhand/product/service/ProductService.java
@@ -13,10 +13,15 @@ import team05a.secondhand.category.repository.CategoryRepository;
 import team05a.secondhand.errors.exception.AddressNotFoundException;
 import team05a.secondhand.errors.exception.CategoryNotFoundException;
 import team05a.secondhand.errors.exception.MemberNotFoundException;
+import team05a.secondhand.errors.exception.ProductNotFoundException;
 import team05a.secondhand.errors.exception.StatusNotFoundException;
+import team05a.secondhand.errors.exception.UnauthorizedProductModificationException;
+import team05a.secondhand.image.service.ImageService;
 import team05a.secondhand.member.data.entity.Member;
 import team05a.secondhand.member.repository.MemberRepository;
 import team05a.secondhand.product.data.dto.ProductCreateRequest;
+import team05a.secondhand.product.data.dto.ProductIdResponse;
+import team05a.secondhand.product.data.dto.ProductUpdateRequest;
 import team05a.secondhand.product.data.entity.Product;
 import team05a.secondhand.product.repository.ProductRepository;
 import team05a.secondhand.status.data.entity.Status;
@@ -32,9 +37,16 @@ public class ProductService {
 	private final CategoryRepository categoryRepository;
 	private final AddressRepository addressRepository;
 	private final StatusRepository statusRepository;
+	private final ImageService imageService;
 
-	public Product create(ProductCreateRequest productCreateRequest, Long memberId,
-		List<String> imageUrls) {
+	public ProductIdResponse create(ProductCreateRequest productCreateRequest, Long memberId) {
+		List<String> imageUrls = imageService.upload(productCreateRequest.getImages());
+		Product product = createProduct(productCreateRequest, memberId, imageUrls);
+		imageService.create(product, imageUrls);
+		return ProductIdResponse.from(product.getId());
+	}
+
+	private Product createProduct(ProductCreateRequest productCreateRequest, Long memberId, List<String> imageUrls) {
 		Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
 		Category category = categoryRepository.findById(productCreateRequest.getCategoryId())
 			.orElseThrow(CategoryNotFoundException::new);
@@ -43,5 +55,51 @@ public class ProductService {
 		Status status = statusRepository.findById(1L).orElseThrow(StatusNotFoundException::new);
 		return productRepository.save(
 			productCreateRequest.toEntity(member, category, address, status, imageUrls.get(0)));
+	}
+
+	public ProductIdResponse update(ProductUpdateRequest productUpdateRequest, Long productId, Long memberId) {
+		validateProductSeller(productId, memberId);
+		imageService.deleteAllBy(productUpdateRequest.getDeletedImageIds());
+		Long imageCount = imageService.count(productId);
+		List<String> newImageUrls = imageService.uploadNew(imageCount, productUpdateRequest.getNewImages());
+		String thumbnailUrl = getThumbnailUrl(imageCount, newImageUrls);
+		Product updateProduct = updateProduct(productUpdateRequest, productId, thumbnailUrl);
+		imageService.create(updateProduct, newImageUrls);
+		return ProductIdResponse.from(updateProduct.getId());
+	}
+
+	private String getThumbnailUrl(Long imageCount, List<String> newImageUrls) {
+		if (imageCount == 0) {
+			return newImageUrls.get(0);
+		}
+		return null;
+	}
+
+	private Product updateProduct(ProductUpdateRequest productUpdateRequest, Long productId, String thumbnailUrl) {
+		Product product = productRepository.findById(productId).orElseThrow(ProductNotFoundException::new);
+		Category category = categoryRepository.findById(productUpdateRequest.getCategoryId())
+			.orElseThrow(CategoryNotFoundException::new);
+		Address address = addressRepository.findById(productUpdateRequest.getAddressId())
+			.orElseThrow(AddressNotFoundException::new);
+		thumbnailUrl = (thumbnailUrl == null) ? imageService.findThumbnail(product) : thumbnailUrl;
+		return product.modify(productUpdateRequest, category, address, thumbnailUrl);
+	}
+
+	private void validateProductSeller(Long productId, Long memberId) {
+		existProduct(productId);
+		Member member = existMember(memberId);
+		if (!productRepository.existsByIdAndMember(productId, member)) {
+			throw new UnauthorizedProductModificationException();
+		}
+	}
+
+	private Member existMember(Long memberId) {
+		return memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+	}
+
+	private void existProduct(Long productId) {
+		if (!productRepository.existsById(productId)) {
+			throw new ProductNotFoundException();
+		}
 	}
 }

--- a/be/src/test/java/team05a/secondhand/address/integration/AddressTest.java
+++ b/be/src/test/java/team05a/secondhand/address/integration/AddressTest.java
@@ -8,8 +8,9 @@ import org.springframework.http.HttpStatus;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import team05a.secondhand.AcceptanceTest;
 
-public class AddressTest {
+public class AddressTest extends AcceptanceTest {
 
 	@DisplayName("동네 목록 조회를 한다.")
 	@Test

--- a/be/src/test/java/team05a/secondhand/category/integration/CategoryTest.java
+++ b/be/src/test/java/team05a/secondhand/category/integration/CategoryTest.java
@@ -8,8 +8,9 @@ import org.springframework.http.HttpStatus;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import team05a.secondhand.AcceptanceTest;
 
-public class CategoryTest {
+public class CategoryTest extends AcceptanceTest {
 
 	@DisplayName("카테고리 목록 조회를 한다.")
 	@Test

--- a/be/src/test/java/team05a/secondhand/fixture/FixtureFactory.java
+++ b/be/src/test/java/team05a/secondhand/fixture/FixtureFactory.java
@@ -13,6 +13,8 @@ import team05a.secondhand.image.data.entity.ProductImage;
 import team05a.secondhand.member.data.entity.Member;
 import team05a.secondhand.oauth.OauthAttributes;
 import team05a.secondhand.product.data.dto.ProductCreateRequest;
+import team05a.secondhand.product.data.dto.ProductIdResponse;
+import team05a.secondhand.product.data.dto.ProductUpdateRequest;
 import team05a.secondhand.product.data.entity.Product;
 import team05a.secondhand.status.data.entity.Status;
 
@@ -60,7 +62,12 @@ public class FixtureFactory {
 	}
 
 	public static Member createMember() {
-		return new Member(OauthAttributes.GITHUB, "wis@naver.com", "wisdom", "imageUrl");
+		return Member.builder()
+			.type(OauthAttributes.GITHUB)
+			.email("wis@naver.com")
+			.nickname("wisdom")
+			.profileImgUrl("imageUrl")
+			.build();
 	}
 
 	public static Category createCategory() {
@@ -97,5 +104,29 @@ public class FixtureFactory {
 			.product(product)
 			.imageUrl("imageUrl")
 			.build());
+	}
+
+	public static ProductIdResponse createProductIdResponse() {
+		return ProductIdResponse.builder()
+			.productId(1L)
+			.build();
+	}
+
+	public static Product createProduct(Member member) {
+		return Product.builder()
+			.member(member)
+			.title("제목")
+			.content("내용")
+			.price("")
+			.thumbnailUrl("썸네일")
+			.build();
+	}
+
+	public static ProductUpdateRequest productUpdateRequest() {
+		return ProductUpdateRequest.builder()
+			.title("update")
+			.content("update")
+			.price("")
+			.build();
 	}
 }

--- a/be/src/test/java/team05a/secondhand/image/repository/ImageRepositoryTest.java
+++ b/be/src/test/java/team05a/secondhand/image/repository/ImageRepositoryTest.java
@@ -1,5 +1,7 @@
 package team05a.secondhand.image.repository;
 
+import static org.assertj.core.api.Assertions.*;
+
 import java.util.List;
 
 import org.assertj.core.api.SoftAssertions;
@@ -34,5 +36,32 @@ class ImageRepositoryTest extends AcceptanceTest {
 				.isEqualTo(productImages.get(0).getProduct().getTitle());
 			softAssertions.assertThat(save.get(0).getImageUrl()).isEqualTo(productImages.get(0).getImageUrl());
 		});
+	}
+
+	@DisplayName("상품 아이디로 이미지 개수를 가져온다.")
+	@Test
+	void countByProductId() {
+		//given & when
+		Product product = productRepository.save(FixtureFactory.createProductRequest());
+		List<ProductImage> productImages = FixtureFactory.createProductImageListRequest(product);
+		List<ProductImage> save = imageRepository.saveAll(productImages);
+		Long count = imageRepository.countByProductId(product.getId());
+
+		//then
+		assertThat(count).isEqualTo(save.size());
+	}
+
+	@DisplayName("상품으로 첫번째 이미지를 찾는다.")
+	@Test
+	void findFirstByProduct() {
+		//given & when
+		Product product = productRepository.save(FixtureFactory.createProductRequest());
+		List<ProductImage> productImages = FixtureFactory.createProductImageListRequest(product);
+		List<ProductImage> save = imageRepository.saveAll(productImages);
+		ProductImage productImage = imageRepository.findFirstByProduct(product);
+
+		//then
+		assertThat(productImage.getId()).isEqualTo(save.get(0).getId());
+		assertThat(productImage.getImageUrl()).isEqualTo(save.get(0).getImageUrl());
 	}
 }

--- a/be/src/test/java/team05a/secondhand/product/controller/ProductControllerTest.java
+++ b/be/src/test/java/team05a/secondhand/product/controller/ProductControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpMethod;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
@@ -42,10 +43,28 @@ class ProductControllerTest {
 		mockingMemberId();
 
 		// given
-		given(productService.create(any(), any(), any())).willReturn(FixtureFactory.createProductResponse());
+		given(productService.create(any(), any())).willReturn(FixtureFactory.createProductIdResponse());
 
 		//when & then
 		mockMvc.perform(multipart("/api/products")
+				.param("title", "title")
+				.param("content", "content"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.productId").exists())
+			.andDo(print());
+	}
+
+	@DisplayName("상품을 수정한다.")
+	@Test
+	void update() throws Exception {
+		// mocking
+		mockingMemberId();
+
+		// given
+		given(productService.update(any(), any(), any())).willReturn(FixtureFactory.createProductIdResponse());
+
+		//when & then
+		mockMvc.perform(multipart(HttpMethod.PATCH, "/api/products/1")
 				.param("title", "title")
 				.param("content", "content"))
 			.andExpect(status().isOk())

--- a/be/src/test/java/team05a/secondhand/product/repository/ProductRepositoryTest.java
+++ b/be/src/test/java/team05a/secondhand/product/repository/ProductRepositoryTest.java
@@ -1,5 +1,7 @@
 package team05a.secondhand.product.repository;
 
+import static org.assertj.core.api.Assertions.*;
+
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,5 +29,17 @@ class ProductRepositoryTest extends AcceptanceTest {
 			softAssertions.assertThat(save.getContent()).isEqualTo(product.getContent());
 			softAssertions.assertThat(save.getThumbnailUrl()).isEqualTo(product.getThumbnailUrl());
 		});
+	}
+
+	@DisplayName("상품 아이디와 멤버로 상품이 존재하는지 확인한다.")
+	@Test
+	void existsByIdAndMember() {
+		//given & when
+		Product product = FixtureFactory.createProductRequest();
+		Product save = productRepository.save(product);
+		boolean exists = productRepository.existsByIdAndMember(save.getId(), save.getMember());
+
+		//then
+		assertThat(exists).isTrue();
 	}
 }

--- a/be/src/test/java/team05a/secondhand/product/service/ProductServiceTest.java
+++ b/be/src/test/java/team05a/secondhand/product/service/ProductServiceTest.java
@@ -15,9 +15,17 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import team05a.secondhand.address.repository.AddressRepository;
 import team05a.secondhand.category.repository.CategoryRepository;
+import team05a.secondhand.errors.exception.AddressNotFoundException;
+import team05a.secondhand.errors.exception.CategoryNotFoundException;
+import team05a.secondhand.errors.exception.MemberNotFoundException;
+import team05a.secondhand.errors.exception.ProductNotFoundException;
+import team05a.secondhand.errors.exception.UnauthorizedProductModificationException;
 import team05a.secondhand.fixture.FixtureFactory;
+import team05a.secondhand.image.service.ImageService;
 import team05a.secondhand.member.repository.MemberRepository;
 import team05a.secondhand.product.data.dto.ProductCreateRequest;
+import team05a.secondhand.product.data.dto.ProductIdResponse;
+import team05a.secondhand.product.data.dto.ProductUpdateRequest;
 import team05a.secondhand.product.data.entity.Product;
 import team05a.secondhand.product.repository.ProductRepository;
 import team05a.secondhand.status.repository.StatusRepository;
@@ -37,24 +45,131 @@ class ProductServiceTest {
 	private StatusRepository statusRepository;
 	@Mock
 	private ProductRepository productRepository;
+	@Mock
+	private ImageService imageService;
 
 	@DisplayName("상품을 등록한다.")
 	@Test
 	void createProduct() {
 		// given
+		ProductCreateRequest productCreateRequest = FixtureFactory.productCreateRequest();
+		Product productResponse = FixtureFactory.createProductResponse();
+		List<String> imageUrls = List.of("imageUrl");
+		given(imageService.upload(any())).willReturn(imageUrls);
 		given(memberRepository.findById(any())).willReturn(Optional.of(FixtureFactory.createMember()));
 		given(categoryRepository.findById(any())).willReturn(Optional.ofNullable(FixtureFactory.createCategory()));
 		given(addressRepository.findById(any())).willReturn(Optional.ofNullable(FixtureFactory.createAddress()));
 		given(statusRepository.findById(any())).willReturn(Optional.ofNullable(FixtureFactory.createStatus()));
-		given(productRepository.save(any())).willReturn(FixtureFactory.createProductResponse());
-		List<String> imageUrls = List.of("imageUrl");
-		ProductCreateRequest productCreateRequest = FixtureFactory.productCreateRequest();
+		given(productRepository.save(any())).willReturn(productResponse);
 
 		//when
-		Product product = productService.create(productCreateRequest, 1L, imageUrls);
+		ProductIdResponse productIdResponse = productService.create(productCreateRequest, 1L);
 
 		//then
-		assertThat(product.getTitle()).isEqualTo(productCreateRequest.getTitle());
-		assertThat(product.getContent()).isEqualTo(productCreateRequest.getContent());
+		assertThat(productIdResponse.getProductId()).isEqualTo(productResponse.getId());
+	}
+
+	@DisplayName("상품을 수정한다.")
+	@Test
+	void updateProduct() {
+		// given
+		ProductUpdateRequest productUpdateRequest = FixtureFactory.productUpdateRequest();
+		Product productResponse = FixtureFactory.createProductResponse();
+		List<String> imageUrls = List.of("imageUrl");
+		given(imageService.count(any())).willReturn(1L);
+		given(imageService.uploadNew(any(), any())).willReturn(imageUrls);
+		given(productRepository.existsById(any())).willReturn(true);
+		given(memberRepository.findById(any())).willReturn(Optional.ofNullable(FixtureFactory.createMember()));
+		given(productRepository.existsByIdAndMember(any(), any())).willReturn(true);
+		given(productRepository.findById(any())).willReturn(
+			Optional.ofNullable(FixtureFactory.createProductResponse()));
+		given(categoryRepository.findById(any())).willReturn(Optional.ofNullable(FixtureFactory.createCategory()));
+		given(addressRepository.findById(any())).willReturn(Optional.ofNullable(FixtureFactory.createAddress()));
+
+		//when
+		ProductIdResponse productIdResponse = productService.update(productUpdateRequest, 1L, 1L);
+
+		//then
+		assertThat(productIdResponse.getProductId()).isEqualTo(productResponse.getId());
+	}
+
+	@DisplayName("상품을 수정 시 상품이 없을 경우 400 에러를 반환한다.")
+	@Test
+	void update_fail_ProductNotFound() {
+		// given
+		ProductUpdateRequest productUpdateRequest = FixtureFactory.productUpdateRequest();
+		given(productRepository.existsById(any())).willReturn(false);
+
+		// when & then
+		assertThatThrownBy(() -> productService.update(productUpdateRequest, 1L, 1L)).isInstanceOf(
+			ProductNotFoundException.class);
+	}
+
+	@DisplayName("상품을 수정 시 멤버가 없을 경우 400 에러를 반환한다.")
+	@Test
+	void update_fail_MemberNotFound() {
+		// given
+		ProductUpdateRequest productUpdateRequest = FixtureFactory.productUpdateRequest();
+		given(productRepository.existsById(any())).willReturn(true);
+		given(memberRepository.findById(any())).willReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> productService.update(productUpdateRequest, 1L, 1L)).isInstanceOf(
+			MemberNotFoundException.class);
+	}
+
+	@DisplayName("상품을 수정 시 멤버가 다를 경우 400 에러를 반환한다.")
+	@Test
+	void update_fail_UnauthorizedMember() {
+		// given
+		ProductUpdateRequest productUpdateRequest = FixtureFactory.productUpdateRequest();
+		given(productRepository.existsById(any())).willReturn(true);
+		given(memberRepository.findById(any())).willReturn(Optional.ofNullable(FixtureFactory.createMember()));
+		given(productRepository.existsByIdAndMember(any(), any())).willReturn(false);
+
+		// when & then
+		assertThatThrownBy(() -> productService.update(productUpdateRequest, 1L, 1L)).isInstanceOf(
+			UnauthorizedProductModificationException.class);
+	}
+
+	@DisplayName("상품을 수정 시 없는 카테고리일 경우 400 에러를 반환한다.")
+	@Test
+	void update_fail_CategoryNotFound() {
+		// given
+		ProductUpdateRequest productUpdateRequest = FixtureFactory.productUpdateRequest();
+		List<String> imageUrls = List.of("imageUrl");
+		given(productRepository.existsById(any())).willReturn(true);
+		given(memberRepository.findById(any())).willReturn(Optional.ofNullable(FixtureFactory.createMember()));
+		given(productRepository.existsByIdAndMember(any(), any())).willReturn(true);
+		given(imageService.count(any())).willReturn(1L);
+		given(imageService.uploadNew(any(), any())).willReturn(imageUrls);
+		given(productRepository.findById(any())).willReturn(
+			Optional.ofNullable(FixtureFactory.createProductResponse()));
+		given(categoryRepository.findById(any())).willReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> productService.update(productUpdateRequest, 1L, 1L)).isInstanceOf(
+			CategoryNotFoundException.class);
+	}
+
+	@DisplayName("상품을 수정 시 없는 주소일 경우 400 에러를 반환한다.")
+	@Test
+	void update_fail_AddressNotFoundException() {
+		// given
+		ProductUpdateRequest productUpdateRequest = FixtureFactory.productUpdateRequest();
+		List<String> imageUrls = List.of("imageUrl");
+		given(productRepository.existsById(any())).willReturn(true);
+		given(memberRepository.findById(any())).willReturn(Optional.ofNullable(FixtureFactory.createMember()));
+		given(productRepository.existsByIdAndMember(any(), any())).willReturn(true);
+		given(imageService.count(any())).willReturn(1L);
+		given(imageService.uploadNew(any(), any())).willReturn(imageUrls);
+		given(productRepository.findById(any())).willReturn(
+			Optional.ofNullable(FixtureFactory.createProductResponse()));
+		given(categoryRepository.findById(any())).willReturn(Optional.ofNullable(FixtureFactory.createCategory()));
+		given(addressRepository.findById(any())).willReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> productService.update(productUpdateRequest, 1L, 1L)).isInstanceOf(
+			AddressNotFoundException.class);
 	}
 }

--- a/be/src/test/java/team05a/secondhand/product/service/ProductServiceTest.java
+++ b/be/src/test/java/team05a/secondhand/product/service/ProductServiceTest.java
@@ -76,7 +76,7 @@ class ProductServiceTest {
 		ProductUpdateRequest productUpdateRequest = FixtureFactory.productUpdateRequest();
 		Product productResponse = FixtureFactory.createProductResponse();
 		List<String> imageUrls = List.of("imageUrl");
-		given(imageService.count(any())).willReturn(1L);
+		given(imageService.countImagesBy(any())).willReturn(1L);
 		given(imageService.uploadNew(any(), any())).willReturn(imageUrls);
 		given(productRepository.existsById(any())).willReturn(true);
 		given(memberRepository.findById(any())).willReturn(Optional.ofNullable(FixtureFactory.createMember()));
@@ -141,7 +141,7 @@ class ProductServiceTest {
 		given(productRepository.existsById(any())).willReturn(true);
 		given(memberRepository.findById(any())).willReturn(Optional.ofNullable(FixtureFactory.createMember()));
 		given(productRepository.existsByIdAndMember(any(), any())).willReturn(true);
-		given(imageService.count(any())).willReturn(1L);
+		given(imageService.countImagesBy(any())).willReturn(1L);
 		given(imageService.uploadNew(any(), any())).willReturn(imageUrls);
 		given(productRepository.findById(any())).willReturn(
 			Optional.ofNullable(FixtureFactory.createProductResponse()));
@@ -161,7 +161,7 @@ class ProductServiceTest {
 		given(productRepository.existsById(any())).willReturn(true);
 		given(memberRepository.findById(any())).willReturn(Optional.ofNullable(FixtureFactory.createMember()));
 		given(productRepository.existsByIdAndMember(any(), any())).willReturn(true);
-		given(imageService.count(any())).willReturn(1L);
+		given(imageService.countImagesBy(any())).willReturn(1L);
 		given(imageService.uploadNew(any(), any())).willReturn(imageUrls);
 		given(productRepository.findById(any())).willReturn(
 			Optional.ofNullable(FixtureFactory.createProductResponse()));


### PR DESCRIPTION
## 🔑 Key changes
- `validateProductSeller` -> 상품이 존재하는지 멤버가 존재하는지 확인 후 상품의 판매자와 수정을 누른 멤버가 같은지 확인
- 삭제된 이미지 아이디를 받아 상품 이미지 테이블에서 삭제
- 상품 아이디로 상품 이미지 개수를 받고 전체 이미지 수가 10개가 넘거나 0개라면 예외 발생
- 예외가 발생하지 않는다면 상품 이미지 등록
- 원래 있던 이미지가 0개라면 새로운 이미지 중 첫번째를 썸네일로 지정
- 상품, 카테고리, 주소가 없다면 예외발생 그리고 원래 이미지가 있다면 그 중 첫번째로 썸네일 url 지정
- 모든 내용을 받아서 상품 테이블을 수정
- 새로운 이미지 상품 이미지 테이블에 저장
