### PR TITLE
[BE] access token 재발급 API 구현

### DIFF
--- a/be/src/main/java/team05a/secondhand/filter/JwtAuthorizationFilter.java
+++ b/be/src/main/java/team05a/secondhand/filter/JwtAuthorizationFilter.java
@@ -32,6 +32,7 @@ public class JwtAuthorizationFilter implements Filter {
 
 	private final String[] whiteListGetUris = new String[] {"/api/addresses", "/api/categories", "/api/products*",
 		"/api/statuses"};
+	private final String[] whiteListPostUris = new String[] {"/api/members/sign-in/*", "/api/reissue-access-token"};
 	private final JwtTokenProvider jwtProvider;
 	private final MemberRefreshTokenRepository memberRefreshTokenRepository;
 
@@ -80,8 +81,7 @@ public class JwtAuthorizationFilter implements Filter {
 
 	private boolean whiteListLoginCheck(HttpServletRequest httpServletRequest) {
 		String uri = httpServletRequest.getRequestURI();
-		String whiteListLoginUris = "/api/members/sign-in/*";
-		return httpServletRequest.getMethod().equals("POST") && PatternMatchUtils.simpleMatch(whiteListLoginUris, uri);
+		return httpServletRequest.getMethod().equals("POST") && PatternMatchUtils.simpleMatch(whiteListPostUris, uri);
 	}
 
 	private boolean isContainToken(HttpServletRequest request) {

--- a/be/src/main/java/team05a/secondhand/oauth/controller/OauthController.java
+++ b/be/src/main/java/team05a/secondhand/oauth/controller/OauthController.java
@@ -24,6 +24,7 @@ import team05a.secondhand.jwt.resolver.AccessToken;
 import team05a.secondhand.member.resolver.MemberId;
 import team05a.secondhand.oauth.InMemoryProviderRepository;
 import team05a.secondhand.oauth.OauthAttributes;
+import team05a.secondhand.oauth.data.dto.AccessTokenResponse;
 import team05a.secondhand.oauth.data.dto.MemberOauthRequest;
 import team05a.secondhand.oauth.data.dto.OauthAccessCode;
 import team05a.secondhand.oauth.data.dto.OauthRefreshTokenRequest;
@@ -58,6 +59,17 @@ public class OauthController {
 		oauthService.logout(oauthRefreshTokenRequest, accessToken, memberId);
 
 		return ResponseEntity.ok().build();
+	}
+
+	@PostMapping("/reissue-access-token")
+	public ResponseEntity<AccessTokenResponse> reissueAccessToken(
+		@RequestBody OauthRefreshTokenRequest oauthRefreshTokenRequest) {
+		String accessToken = oauthService.reissueAccessToken(oauthRefreshTokenRequest);
+		String authorization = "Bearer " + accessToken;
+
+		return ResponseEntity.ok()
+			.header(HttpHeaders.AUTHORIZATION, authorization)
+			.body(AccessTokenResponse.from(accessToken));
 	}
 
 	private OauthTokenResponse getToken(String code, OauthProvider provider) {

--- a/be/src/main/java/team05a/secondhand/oauth/data/dto/AccessTokenResponse.java
+++ b/be/src/main/java/team05a/secondhand/oauth/data/dto/AccessTokenResponse.java
@@ -1,0 +1,21 @@
+package team05a.secondhand.oauth.data.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class AccessTokenResponse {
+
+	private final String accessToken;
+
+	@Builder
+	private AccessTokenResponse(String accessToken) {
+		this.accessToken = accessToken;
+	}
+
+	public static AccessTokenResponse from(String accessToken) {
+		return AccessTokenResponse.builder()
+			.accessToken(accessToken)
+			.build();
+	}
+}

--- a/be/src/main/java/team05a/secondhand/oauth/service/OauthService.java
+++ b/be/src/main/java/team05a/secondhand/oauth/service/OauthService.java
@@ -54,10 +54,20 @@ public class OauthService {
 	}
 
 	private void validateRedisMemberId(String refreshToken, Long memberId) {
-		Long redisMemberId = Long.parseLong(String.valueOf(
-			memberRefreshTokenRepository.get(refreshToken).orElseThrow(RefreshTokenNotFoundException::new)));
+		Long redisMemberId = checkRefreshToken(refreshToken);
 		if (!redisMemberId.equals(memberId)) {
 			throw new TokenMemberMismatchException();
 		}
+	}
+
+	public String reissueAccessToken(OauthRefreshTokenRequest oauthRefreshTokenRequest) {
+		String refreshToken = REFRESH_TOKEN_PREFIX + oauthRefreshTokenRequest.getRefreshToken();
+		Long memberId = checkRefreshToken(refreshToken);
+		return jwtTokenProvider.createAccessToken(Map.of("memberId", memberId));
+	}
+
+	private Long checkRefreshToken(String refreshToken) {
+		return Long.parseLong(String.valueOf(
+			memberRefreshTokenRepository.get(refreshToken).orElseThrow(RefreshTokenNotFoundException::new)));
 	}
 }

--- a/be/src/test/java/team05a/secondhand/oauth/integration/OauthTest.java
+++ b/be/src/test/java/team05a/secondhand/oauth/integration/OauthTest.java
@@ -53,6 +53,34 @@ public class OauthTest extends AcceptanceTest {
 			.extract();
 	}
 
+	@DisplayName("액세스 토큰 재발급을 받는다.")
+	@Test
+	void reissueAccessToken_success() {
+		// given
+		Jwt jwt = login();
+		OauthRefreshTokenRequest oauthRefreshTokenRequest = OauthRefreshTokenRequest.builder()
+			.refreshToken(jwt.getRefreshToken())
+			.build();
+
+		// when
+		var response = reissueAccessToken(oauthRefreshTokenRequest);
+
+		// then
+		assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+		assertThat(response.jsonPath().getString("accessToken")).isNotNull();
+	}
+
+	private ExtractableResponse<Response> reissueAccessToken(OauthRefreshTokenRequest oauthRefreshTokenRequest) {
+		return RestAssured
+			.given().log().all()
+			.body(oauthRefreshTokenRequest)
+			.contentType(MediaType.APPLICATION_JSON_VALUE)
+			.when()
+			.post("/api/reissue-access-token")
+			.then().log().all()
+			.extract();
+	}
+
 	private Jwt login() {
 		return oauthService.login(FixtureFactory.createMemberRequest());
 	}


### PR DESCRIPTION
## 🔑 Key changes
- 액세스 토큰 기한이 만료되면 예외 발생 -> 액세스 토큰 재발급 -> 따라서 Authorization 헤더에 값이 없다고 생각하여 화이트리스트에 액세스 토큰 재발급 uri 추가
- 리프레시 토큰이 Redis에 존재하는지 확인
  - 없다면 RefreshTokenNotFoundException 발생
- 액세스 토큰 재발급
- 관련 통합 테스트 작성