### PR TITLE
[BE] 채팅방 생성 기능 구현

### DIFF
--- a/be/src/main/java/team05a/secondhand/chat/controller/ChatController.java
+++ b/be/src/main/java/team05a/secondhand/chat/controller/ChatController.java
@@ -23,17 +23,17 @@ public class ChatController {
 	private final ChatService chatService;
 
 	@PostMapping("/room")
-	public ResponseEntity<ChatRoomUuidResponse> createChatRoom(@MemberId Long memberId,
+	public ResponseEntity<ChatRoomUuidResponse> createChatRoom(@MemberId Long buyerId,
 		@Valid @RequestBody ChatRoomCreateRequest chatRoomCreateRequest) {
-		checkBuyerIdAndSenderIdSame(memberId, chatRoomCreateRequest);
-		ChatRoomUuidResponse chatRoomUuidResponse = chatService.createChatRoom(memberId, chatRoomCreateRequest);
+		checkBuyerIdAndSenderIdSame(buyerId, chatRoomCreateRequest);
+		ChatRoomUuidResponse chatRoomUuidResponse = chatService.createChatRoom(buyerId, chatRoomCreateRequest);
 
 		return ResponseEntity.ok()
 			.body(chatRoomUuidResponse);
 	}
 
-	private void checkBuyerIdAndSenderIdSame(Long memberId, ChatRoomCreateRequest chatRoomCreateRequest) {
-		if (!memberId.equals(chatRoomCreateRequest.getMessage().getSenderId())) {
+	private void checkBuyerIdAndSenderIdSame(Long buyerId, ChatRoomCreateRequest chatRoomCreateRequest) {
+		if (!buyerId.equals(chatRoomCreateRequest.getMessage().getSenderId())) {
 			throw new BuyerIdAndMessageSenderIdNotSameException();
 		}
 	}

--- a/be/src/main/java/team05a/secondhand/chat/controller/ChatController.java
+++ b/be/src/main/java/team05a/secondhand/chat/controller/ChatController.java
@@ -1,0 +1,32 @@
+package team05a.secondhand.chat.controller;
+
+import javax.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import team05a.secondhand.chat.data.dto.ChatRoomCreateRequest;
+import team05a.secondhand.chat.data.dto.ChatRoomUuidResponse;
+import team05a.secondhand.chat.service.ChatService;
+import team05a.secondhand.member.resolver.MemberId;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/chat")
+public class ChatController {
+
+	private final ChatService chatService;
+
+	@PostMapping("/room")
+	public ResponseEntity<ChatRoomUuidResponse> createChatRoom(@MemberId Long memberId,
+		@Valid @RequestBody ChatRoomCreateRequest chatRoomCreateRequest) {
+		ChatRoomUuidResponse chatRoomUuidResponse = chatService.createChatRoom(memberId, chatRoomCreateRequest);
+
+		return ResponseEntity.ok()
+			.body(chatRoomUuidResponse);
+	}
+}

--- a/be/src/main/java/team05a/secondhand/chat/controller/ChatController.java
+++ b/be/src/main/java/team05a/secondhand/chat/controller/ChatController.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import team05a.secondhand.chat.data.dto.ChatRoomCreateRequest;
 import team05a.secondhand.chat.data.dto.ChatRoomUuidResponse;
 import team05a.secondhand.chat.service.ChatService;
+import team05a.secondhand.errors.exception.BuyerIdAndMessageSenderIdNotSameException;
 import team05a.secondhand.member.resolver.MemberId;
 
 @RestController
@@ -24,9 +25,16 @@ public class ChatController {
 	@PostMapping("/room")
 	public ResponseEntity<ChatRoomUuidResponse> createChatRoom(@MemberId Long memberId,
 		@Valid @RequestBody ChatRoomCreateRequest chatRoomCreateRequest) {
+		checkBuyerIdAndSenderIdSame(memberId, chatRoomCreateRequest);
 		ChatRoomUuidResponse chatRoomUuidResponse = chatService.createChatRoom(memberId, chatRoomCreateRequest);
 
 		return ResponseEntity.ok()
 			.body(chatRoomUuidResponse);
+	}
+
+	private void checkBuyerIdAndSenderIdSame(Long memberId, ChatRoomCreateRequest chatRoomCreateRequest) {
+		if (!memberId.equals(chatRoomCreateRequest.getMessage().getSenderId())) {
+			throw new BuyerIdAndMessageSenderIdNotSameException();
+		}
 	}
 }

--- a/be/src/main/java/team05a/secondhand/chat/data/dto/ChatRoomCreateRequest.java
+++ b/be/src/main/java/team05a/secondhand/chat/data/dto/ChatRoomCreateRequest.java
@@ -1,0 +1,23 @@
+package team05a.secondhand.chat.data.dto;
+
+import javax.validation.constraints.NotNull;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class ChatRoomCreateRequest {
+
+	@NotNull(message = "상품 아이디는 있어야 합니다.")
+	private Long productId;
+	@NotNull
+	private MessageCreateRequest message;
+
+	@Builder
+	private ChatRoomCreateRequest(Long productId, MessageCreateRequest message) {
+		this.productId = productId;
+		this.message = message;
+	}
+}

--- a/be/src/main/java/team05a/secondhand/chat/data/dto/ChatRoomUuidResponse.java
+++ b/be/src/main/java/team05a/secondhand/chat/data/dto/ChatRoomUuidResponse.java
@@ -1,0 +1,18 @@
+package team05a.secondhand.chat.data.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ChatRoomUuidResponse {
+
+	@JsonProperty("roomId")
+	private final String roomUuid;
+
+	@Builder
+	private ChatRoomUuidResponse(String roomUuid) {
+		this.roomUuid = roomUuid;
+	}
+}

--- a/be/src/main/java/team05a/secondhand/chat/data/dto/MessageCreateRequest.java
+++ b/be/src/main/java/team05a/secondhand/chat/data/dto/MessageCreateRequest.java
@@ -1,0 +1,24 @@
+package team05a.secondhand.chat.data.dto;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class MessageCreateRequest {
+
+	@NotNull(message = "메세지를 보내는 사람의 아이디는 필수입니다.")
+	private Long senderId;
+	@NotBlank(message = "메세지에는 빈 값일 수 없고 공백문자만으로 이루어질 수 없습니다.")
+	private String content;
+
+	@Builder
+	private MessageCreateRequest(Long senderId, String content) {
+		this.senderId = senderId;
+		this.content = content;
+	}
+}

--- a/be/src/main/java/team05a/secondhand/chat/data/entity/ChatRoom.java
+++ b/be/src/main/java/team05a/secondhand/chat/data/entity/ChatRoom.java
@@ -1,0 +1,42 @@
+package team05a.secondhand.chat.data.entity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import team05a.secondhand.member.data.entity.Member;
+import team05a.secondhand.product.data.entity.Product;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class ChatRoom {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "chat_room_id")
+	private Long id;
+	private String uuid;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "product_id")
+	private Product product;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id")
+	private Member buyer;
+
+	@Builder
+	private ChatRoom(Long id, String uuid, Product product, Member buyer) {
+		this.id = id;
+		this.uuid = uuid;
+		this.product = product;
+		this.buyer = buyer;
+	}
+}

--- a/be/src/main/java/team05a/secondhand/chat/data/entity/ChatRoom.java
+++ b/be/src/main/java/team05a/secondhand/chat/data/entity/ChatRoom.java
@@ -30,13 +30,13 @@ public class ChatRoom {
 	private Product product;
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "member_id")
-	private Member buyer;
+	private Member member;
 
 	@Builder
-	private ChatRoom(Long id, String uuid, Product product, Member buyer) {
+	private ChatRoom(Long id, String uuid, Product product, Member member) {
 		this.id = id;
 		this.uuid = uuid;
 		this.product = product;
-		this.buyer = buyer;
+		this.member = member;
 	}
 }

--- a/be/src/main/java/team05a/secondhand/chat/data/entity/ChatRoom.java
+++ b/be/src/main/java/team05a/secondhand/chat/data/entity/ChatRoom.java
@@ -1,5 +1,7 @@
 package team05a.secondhand.chat.data.entity;
 
+import java.util.UUID;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -29,14 +31,13 @@ public class ChatRoom {
 	@JoinColumn(name = "product_id")
 	private Product product;
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "member_id")
-	private Member member;
+	@JoinColumn(name = "buyer_id")
+	private Member buyer;
 
 	@Builder
-	private ChatRoom(Long id, String uuid, Product product, Member member) {
-		this.id = id;
-		this.uuid = uuid;
+	private ChatRoom(Product product, Member buyer) {
+		this.uuid = UUID.randomUUID().toString();
 		this.product = product;
-		this.member = member;
+		this.buyer = buyer;
 	}
 }

--- a/be/src/main/java/team05a/secondhand/chat/data/entity/Message.java
+++ b/be/src/main/java/team05a/secondhand/chat/data/entity/Message.java
@@ -1,0 +1,46 @@
+package team05a.secondhand.chat.data.entity;
+
+import java.sql.Timestamp;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.Lob;
+import javax.persistence.ManyToOne;
+
+import org.hibernate.annotations.CreationTimestamp;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import team05a.secondhand.member.data.entity.Member;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class Message {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	private String chatRoomUuid;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id")
+	private Member sender;
+	@Lob
+	private String content;
+	@CreationTimestamp
+	private Timestamp createdTime;
+
+	@Builder
+	private Message(Long id, String chatRoomUuid, Member sender, String content, Timestamp createdTime) {
+		this.id = id;
+		this.chatRoomUuid = chatRoomUuid;
+		this.sender = sender;
+		this.content = content;
+		this.createdTime = createdTime;
+	}
+}

--- a/be/src/main/java/team05a/secondhand/chat/repository/ChatRoomRepository.java
+++ b/be/src/main/java/team05a/secondhand/chat/repository/ChatRoomRepository.java
@@ -6,5 +6,5 @@ import team05a.secondhand.chat.data.entity.ChatRoom;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
-	boolean existsByMemberIdAndProductId(Long memberId, Long productId);
+	boolean existsByBuyerIdAndProductId(Long buyerId, Long productId);
 }

--- a/be/src/main/java/team05a/secondhand/chat/repository/ChatRoomRepository.java
+++ b/be/src/main/java/team05a/secondhand/chat/repository/ChatRoomRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import team05a.secondhand.chat.data.entity.ChatRoom;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+
+	boolean existsByMemberIdAndProductId(Long memberId, Long productId);
 }

--- a/be/src/main/java/team05a/secondhand/chat/repository/ChatRoomRepository.java
+++ b/be/src/main/java/team05a/secondhand/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,8 @@
+package team05a.secondhand.chat.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import team05a.secondhand.chat.data.entity.ChatRoom;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+}

--- a/be/src/main/java/team05a/secondhand/chat/repository/MessageRepository.java
+++ b/be/src/main/java/team05a/secondhand/chat/repository/MessageRepository.java
@@ -1,0 +1,8 @@
+package team05a.secondhand.chat.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import team05a.secondhand.chat.data.entity.Message;
+
+public interface MessageRepository extends JpaRepository<Message, Long> {
+}

--- a/be/src/main/java/team05a/secondhand/chat/service/ChatService.java
+++ b/be/src/main/java/team05a/secondhand/chat/service/ChatService.java
@@ -9,7 +9,9 @@ import lombok.RequiredArgsConstructor;
 import team05a.secondhand.chat.data.dto.ChatRoomCreateRequest;
 import team05a.secondhand.chat.data.dto.ChatRoomUuidResponse;
 import team05a.secondhand.chat.data.entity.ChatRoom;
+import team05a.secondhand.chat.data.entity.Message;
 import team05a.secondhand.chat.repository.ChatRoomRepository;
+import team05a.secondhand.chat.repository.MessageRepository;
 import team05a.secondhand.errors.exception.MemberNotFoundException;
 import team05a.secondhand.errors.exception.ProductNotFoundException;
 import team05a.secondhand.member.data.entity.Member;
@@ -22,6 +24,7 @@ import team05a.secondhand.product.repository.ProductRepository;
 public class ChatService {
 
 	private final ChatRoomRepository chatRoomRepository;
+	private final MessageRepository messageRepository;
 	private final MemberRepository memberRepository;
 	private final ProductRepository productRepository;
 
@@ -30,14 +33,20 @@ public class ChatService {
 		Member buyer = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
 		Product product = productRepository.findById(chatRoomCreateRequest.getProductId())
 			.orElseThrow(ProductNotFoundException::new);
-		String uuid = UUID.randomUUID().toString();
+		String chatRoomUuid = UUID.randomUUID().toString();
 		ChatRoom chatRoom = ChatRoom.builder()
-			.uuid(uuid)
+			.uuid(chatRoomUuid)
 			.buyer(buyer)
 			.product(product)
 			.build();
+		Message message = Message.builder()
+			.chatRoomUuid(chatRoomUuid)
+			.sender(buyer)
+			.content(chatRoomCreateRequest.getMessage().getContent())
+			.build();
 
 		ChatRoom savedChatRoom = chatRoomRepository.save(chatRoom);
+		messageRepository.save(message);
 		return ChatRoomUuidResponse.builder()
 			.roomUuid(savedChatRoom.getUuid())
 			.build();

--- a/be/src/main/java/team05a/secondhand/chat/service/ChatService.java
+++ b/be/src/main/java/team05a/secondhand/chat/service/ChatService.java
@@ -39,8 +39,7 @@ public class ChatService {
 		checkChatRoomExists(buyer, product);
 		String chatRoomUuid = UUID.randomUUID().toString();
 		ChatRoom chatRoom = ChatRoom.builder()
-			.uuid(chatRoomUuid)
-			.member(buyer)
+			.buyer(buyer)
 			.product(product)
 			.build();
 		Message message = Message.builder()
@@ -63,7 +62,7 @@ public class ChatService {
 	}
 
 	private void checkChatRoomExists(Member buyer, Product product) {
-		if (chatRoomRepository.existsByMemberIdAndProductId(buyer.getId(), product.getId())) {
+		if (chatRoomRepository.existsByBuyerIdAndProductId(buyer.getId(), product.getId())) {
 			throw new ChatRoomExistsException();
 		}
 	}

--- a/be/src/main/java/team05a/secondhand/chat/service/ChatService.java
+++ b/be/src/main/java/team05a/secondhand/chat/service/ChatService.java
@@ -14,6 +14,7 @@ import team05a.secondhand.chat.repository.ChatRoomRepository;
 import team05a.secondhand.chat.repository.MessageRepository;
 import team05a.secondhand.errors.exception.MemberNotFoundException;
 import team05a.secondhand.errors.exception.ProductNotFoundException;
+import team05a.secondhand.errors.exception.SellerIdAndBuyerIdSameException;
 import team05a.secondhand.member.data.entity.Member;
 import team05a.secondhand.member.repository.MemberRepository;
 import team05a.secondhand.product.data.entity.Product;
@@ -33,6 +34,7 @@ public class ChatService {
 		Member buyer = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
 		Product product = productRepository.findById(chatRoomCreateRequest.getProductId())
 			.orElseThrow(ProductNotFoundException::new);
+		checkBuyerIdAndSellerIdSame(buyer, product);
 		String chatRoomUuid = UUID.randomUUID().toString();
 		ChatRoom chatRoom = ChatRoom.builder()
 			.uuid(chatRoomUuid)
@@ -52,4 +54,9 @@ public class ChatService {
 			.build();
 	}
 
+	private void checkBuyerIdAndSellerIdSame(Member buyer, Product product) {
+		if (buyer.getId().equals(product.getMember().getId())) {
+			throw new SellerIdAndBuyerIdSameException();
+		}
+	}
 }

--- a/be/src/main/java/team05a/secondhand/chat/service/ChatService.java
+++ b/be/src/main/java/team05a/secondhand/chat/service/ChatService.java
@@ -12,6 +12,7 @@ import team05a.secondhand.chat.data.entity.ChatRoom;
 import team05a.secondhand.chat.data.entity.Message;
 import team05a.secondhand.chat.repository.ChatRoomRepository;
 import team05a.secondhand.chat.repository.MessageRepository;
+import team05a.secondhand.errors.exception.ChatRoomExistsException;
 import team05a.secondhand.errors.exception.MemberNotFoundException;
 import team05a.secondhand.errors.exception.ProductNotFoundException;
 import team05a.secondhand.errors.exception.SellerIdAndBuyerIdSameException;
@@ -35,10 +36,11 @@ public class ChatService {
 		Product product = productRepository.findById(chatRoomCreateRequest.getProductId())
 			.orElseThrow(ProductNotFoundException::new);
 		checkBuyerIdAndSellerIdSame(buyer, product);
+		checkChatRoomExists(buyer, product);
 		String chatRoomUuid = UUID.randomUUID().toString();
 		ChatRoom chatRoom = ChatRoom.builder()
 			.uuid(chatRoomUuid)
-			.buyer(buyer)
+			.member(buyer)
 			.product(product)
 			.build();
 		Message message = Message.builder()
@@ -57,6 +59,12 @@ public class ChatService {
 	private void checkBuyerIdAndSellerIdSame(Member buyer, Product product) {
 		if (buyer.getId().equals(product.getMember().getId())) {
 			throw new SellerIdAndBuyerIdSameException();
+		}
+	}
+
+	private void checkChatRoomExists(Member buyer, Product product) {
+		if (chatRoomRepository.existsByMemberIdAndProductId(buyer.getId(), product.getId())) {
+			throw new ChatRoomExistsException();
 		}
 	}
 }

--- a/be/src/main/java/team05a/secondhand/chat/service/ChatService.java
+++ b/be/src/main/java/team05a/secondhand/chat/service/ChatService.java
@@ -29,8 +29,8 @@ public class ChatService {
 	private final ProductRepository productRepository;
 
 	@Transactional
-	public ChatRoomUuidResponse createChatRoom(Long memberId, ChatRoomCreateRequest chatRoomCreateRequest) {
-		Member buyer = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+	public ChatRoomUuidResponse createChatRoom(Long buyerId, ChatRoomCreateRequest chatRoomCreateRequest) {
+		Member buyer = memberRepository.findById(buyerId).orElseThrow(MemberNotFoundException::new);
 		Product product = productRepository.findById(chatRoomCreateRequest.getProductId())
 			.orElseThrow(ProductNotFoundException::new);
 		checkChatRoomCreationAllowed(buyer, product);

--- a/be/src/main/java/team05a/secondhand/chat/service/ChatService.java
+++ b/be/src/main/java/team05a/secondhand/chat/service/ChatService.java
@@ -1,0 +1,46 @@
+package team05a.secondhand.chat.service;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import team05a.secondhand.chat.data.dto.ChatRoomCreateRequest;
+import team05a.secondhand.chat.data.dto.ChatRoomUuidResponse;
+import team05a.secondhand.chat.data.entity.ChatRoom;
+import team05a.secondhand.chat.repository.ChatRoomRepository;
+import team05a.secondhand.errors.exception.MemberNotFoundException;
+import team05a.secondhand.errors.exception.ProductNotFoundException;
+import team05a.secondhand.member.data.entity.Member;
+import team05a.secondhand.member.repository.MemberRepository;
+import team05a.secondhand.product.data.entity.Product;
+import team05a.secondhand.product.repository.ProductRepository;
+
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+
+	private final ChatRoomRepository chatRoomRepository;
+	private final MemberRepository memberRepository;
+	private final ProductRepository productRepository;
+
+	@Transactional
+	public ChatRoomUuidResponse createChatRoom(Long memberId, ChatRoomCreateRequest chatRoomCreateRequest) {
+		Member buyer = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+		Product product = productRepository.findById(chatRoomCreateRequest.getProductId())
+			.orElseThrow(ProductNotFoundException::new);
+		String uuid = UUID.randomUUID().toString();
+		ChatRoom chatRoom = ChatRoom.builder()
+			.uuid(uuid)
+			.buyer(buyer)
+			.product(product)
+			.build();
+
+		ChatRoom savedChatRoom = chatRoomRepository.save(chatRoom);
+		return ChatRoomUuidResponse.builder()
+			.roomUuid(savedChatRoom.getUuid())
+			.build();
+	}
+
+}

--- a/be/src/main/java/team05a/secondhand/chat/service/ChatService.java
+++ b/be/src/main/java/team05a/secondhand/chat/service/ChatService.java
@@ -1,7 +1,5 @@
 package team05a.secondhand.chat.service;
 
-import java.util.UUID;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,15 +33,13 @@ public class ChatService {
 		Member buyer = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
 		Product product = productRepository.findById(chatRoomCreateRequest.getProductId())
 			.orElseThrow(ProductNotFoundException::new);
-		checkBuyerIdAndSellerIdSame(buyer, product);
-		checkChatRoomExists(buyer, product);
-		String chatRoomUuid = UUID.randomUUID().toString();
+		checkChatRoomCreationAllowed(buyer, product);
 		ChatRoom chatRoom = ChatRoom.builder()
 			.buyer(buyer)
 			.product(product)
 			.build();
 		Message message = Message.builder()
-			.chatRoomUuid(chatRoomUuid)
+			.chatRoomUuid(chatRoom.getUuid())
 			.sender(buyer)
 			.content(chatRoomCreateRequest.getMessage().getContent())
 			.build();
@@ -53,6 +49,11 @@ public class ChatService {
 		return ChatRoomUuidResponse.builder()
 			.roomUuid(savedChatRoom.getUuid())
 			.build();
+	}
+
+	private void checkChatRoomCreationAllowed(Member buyer, Product product) {
+		checkBuyerIdAndSellerIdSame(buyer, product);
+		checkChatRoomExists(buyer, product);
 	}
 
 	private void checkBuyerIdAndSellerIdSame(Member buyer, Product product) {

--- a/be/src/main/java/team05a/secondhand/errors/exception/BuyerIdAndMessageSenderIdNotSameException.java
+++ b/be/src/main/java/team05a/secondhand/errors/exception/BuyerIdAndMessageSenderIdNotSameException.java
@@ -1,0 +1,10 @@
+package team05a.secondhand.errors.exception;
+
+public class BuyerIdAndMessageSenderIdNotSameException extends RuntimeException {
+
+	private static final String MESSAGE = "구매자 아이디와 첫 메세지 발송자 아이디가 일치합니다.";
+
+	public BuyerIdAndMessageSenderIdNotSameException() {
+		super(MESSAGE);
+	}
+}

--- a/be/src/main/java/team05a/secondhand/errors/exception/BuyerIdAndMessageSenderIdNotSameException.java
+++ b/be/src/main/java/team05a/secondhand/errors/exception/BuyerIdAndMessageSenderIdNotSameException.java
@@ -2,7 +2,7 @@ package team05a.secondhand.errors.exception;
 
 public class BuyerIdAndMessageSenderIdNotSameException extends RuntimeException {
 
-	private static final String MESSAGE = "구매자 아이디와 첫 메세지 발송자 아이디가 일치합니다.";
+	private static final String MESSAGE = "구매자 아이디와 첫 메세지 발송자 아이디가 일치하지 않습니다.";
 
 	public BuyerIdAndMessageSenderIdNotSameException() {
 		super(MESSAGE);

--- a/be/src/main/java/team05a/secondhand/errors/exception/ChatRoomExistsException.java
+++ b/be/src/main/java/team05a/secondhand/errors/exception/ChatRoomExistsException.java
@@ -1,0 +1,10 @@
+package team05a.secondhand.errors.exception;
+
+public class ChatRoomExistsException extends RuntimeException {
+
+	private static final String MESSAGE = "해당 제품 아이디와 구매자 아이디로 채팅방이 이미 존재합니다.";
+
+	public ChatRoomExistsException() {
+		super(MESSAGE);
+	}
+}

--- a/be/src/main/java/team05a/secondhand/errors/exception/SellerIdAndBuyerIdSameException.java
+++ b/be/src/main/java/team05a/secondhand/errors/exception/SellerIdAndBuyerIdSameException.java
@@ -1,0 +1,10 @@
+package team05a.secondhand.errors.exception;
+
+public class SellerIdAndBuyerIdSameException extends RuntimeException {
+
+	private static final String MESSAGE = "구매자 아이디와 판매자 아이디가 일치합니다.";
+
+	public SellerIdAndBuyerIdSameException() {
+		super(MESSAGE);
+	}
+}

--- a/be/src/main/java/team05a/secondhand/errors/handler/ChatExceptionHandler.java
+++ b/be/src/main/java/team05a/secondhand/errors/handler/ChatExceptionHandler.java
@@ -1,0 +1,24 @@
+package team05a.secondhand.errors.handler;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import lombok.extern.slf4j.Slf4j;
+import team05a.secondhand.errors.ErrorResponse;
+import team05a.secondhand.errors.exception.BuyerIdAndMessageSenderIdNotSameException;
+
+@Slf4j
+@RestControllerAdvice
+public class ChatExceptionHandler {
+
+	@ExceptionHandler(BuyerIdAndMessageSenderIdNotSameException.class)
+	public ResponseEntity<ErrorResponse> handleAddressNotFoundException(BuyerIdAndMessageSenderIdNotSameException e) {
+		log.warn("BuyerIdAndMessageSenderIdNotSameException handling : {}", e.toString());
+
+		ErrorResponse response = ErrorResponse.from(HttpStatus.BAD_REQUEST, e.getMessage());
+		return ResponseEntity.status(response.getStatus())
+			.body(response);
+	}
+}

--- a/be/src/main/java/team05a/secondhand/errors/handler/ChatExceptionHandler.java
+++ b/be/src/main/java/team05a/secondhand/errors/handler/ChatExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import lombok.extern.slf4j.Slf4j;
 import team05a.secondhand.errors.ErrorResponse;
 import team05a.secondhand.errors.exception.BuyerIdAndMessageSenderIdNotSameException;
+import team05a.secondhand.errors.exception.SellerIdAndBuyerIdSameException;
 
 @Slf4j
 @RestControllerAdvice
@@ -15,6 +16,15 @@ public class ChatExceptionHandler {
 
 	@ExceptionHandler(BuyerIdAndMessageSenderIdNotSameException.class)
 	public ResponseEntity<ErrorResponse> handleAddressNotFoundException(BuyerIdAndMessageSenderIdNotSameException e) {
+		log.warn("BuyerIdAndMessageSenderIdNotSameException handling : {}", e.toString());
+
+		ErrorResponse response = ErrorResponse.from(HttpStatus.BAD_REQUEST, e.getMessage());
+		return ResponseEntity.status(response.getStatus())
+			.body(response);
+	}
+
+	@ExceptionHandler(SellerIdAndBuyerIdSameException.class)
+	public ResponseEntity<ErrorResponse> handleAddressNotFoundException(SellerIdAndBuyerIdSameException e) {
 		log.warn("BuyerIdAndMessageSenderIdNotSameException handling : {}", e.toString());
 
 		ErrorResponse response = ErrorResponse.from(HttpStatus.BAD_REQUEST, e.getMessage());

--- a/be/src/main/java/team05a/secondhand/errors/handler/ChatExceptionHandler.java
+++ b/be/src/main/java/team05a/secondhand/errors/handler/ChatExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import lombok.extern.slf4j.Slf4j;
 import team05a.secondhand.errors.ErrorResponse;
 import team05a.secondhand.errors.exception.BuyerIdAndMessageSenderIdNotSameException;
+import team05a.secondhand.errors.exception.ChatRoomExistsException;
 import team05a.secondhand.errors.exception.SellerIdAndBuyerIdSameException;
 
 @Slf4j
@@ -15,7 +16,8 @@ import team05a.secondhand.errors.exception.SellerIdAndBuyerIdSameException;
 public class ChatExceptionHandler {
 
 	@ExceptionHandler(BuyerIdAndMessageSenderIdNotSameException.class)
-	public ResponseEntity<ErrorResponse> handleAddressNotFoundException(BuyerIdAndMessageSenderIdNotSameException e) {
+	public ResponseEntity<ErrorResponse> handleBuyerIdAndMessageSenderIdNotSameException(
+		BuyerIdAndMessageSenderIdNotSameException e) {
 		log.warn("BuyerIdAndMessageSenderIdNotSameException handling : {}", e.toString());
 
 		ErrorResponse response = ErrorResponse.from(HttpStatus.BAD_REQUEST, e.getMessage());
@@ -24,8 +26,17 @@ public class ChatExceptionHandler {
 	}
 
 	@ExceptionHandler(SellerIdAndBuyerIdSameException.class)
-	public ResponseEntity<ErrorResponse> handleAddressNotFoundException(SellerIdAndBuyerIdSameException e) {
-		log.warn("BuyerIdAndMessageSenderIdNotSameException handling : {}", e.toString());
+	public ResponseEntity<ErrorResponse> handleSellerIdAndBuyerIdSameException(SellerIdAndBuyerIdSameException e) {
+		log.warn("SellerIdAndBuyerIdSameException handling : {}", e.toString());
+
+		ErrorResponse response = ErrorResponse.from(HttpStatus.BAD_REQUEST, e.getMessage());
+		return ResponseEntity.status(response.getStatus())
+			.body(response);
+	}
+
+	@ExceptionHandler(ChatRoomExistsException.class)
+	public ResponseEntity<ErrorResponse> handleChatRoomExistsException(ChatRoomExistsException e) {
+		log.warn("ChatRoomExistsException handling : {}", e.toString());
 
 		ErrorResponse response = ErrorResponse.from(HttpStatus.BAD_REQUEST, e.getMessage());
 		return ResponseEntity.status(response.getStatus())

--- a/be/src/test/java/team05a/secondhand/chat/integration/ChatTest.java
+++ b/be/src/test/java/team05a/secondhand/chat/integration/ChatTest.java
@@ -1,0 +1,70 @@
+package team05a.secondhand.chat.integration;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import team05a.secondhand.DatabaseCleanup;
+import team05a.secondhand.fixture.FixtureFactory;
+import team05a.secondhand.jwt.JwtTokenProvider;
+import team05a.secondhand.member.data.entity.Member;
+import team05a.secondhand.member.repository.MemberRepository;
+import team05a.secondhand.product.data.entity.Product;
+import team05a.secondhand.product.repository.ProductRepository;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class ChatTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+	@Autowired
+	private MemberRepository memberRepository;
+	@Autowired
+	private ProductRepository productRepository;
+	@Autowired
+	private JwtTokenProvider jwtTokenProvider;
+	@Autowired
+	private ObjectMapper objectMapper;
+	@Autowired
+	private DatabaseCleanup databaseCleanup;
+
+	@BeforeEach
+	public void setUp() {
+		databaseCleanup.execute();
+	}
+
+	@Test
+	@DisplayName("채팅방을 만든다.")
+	void createChatRoom() throws Exception {
+		Member member = FixtureFactory.createMember();
+		memberRepository.save(member);
+		Product product = FixtureFactory.createProductRequest(member);
+		productRepository.save(product);
+		String accessToken = jwtTokenProvider.createAccessToken(Map.of("memberId", member.getId()));
+		String requestBody = "{\"productId\": 1,\"message\": {\"senderId\": 1,\"content\": \"얼마야?\"}}";
+
+		ResultActions resultActions = mockMvc.perform(
+				MockMvcRequestBuilders
+					.post("/api/chat/room")
+					.header("Authorization", "Bearer " + accessToken)
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(requestBody)
+			)
+			.andDo(print());
+
+	}
+}

--- a/be/src/test/java/team05a/secondhand/chat/integration/ChatTest.java
+++ b/be/src/test/java/team05a/secondhand/chat/integration/ChatTest.java
@@ -52,8 +52,11 @@ public class ChatTest {
 		memberRepository.save(member);
 		Product product = FixtureFactory.createProductRequest(member);
 		productRepository.save(product);
-		String accessToken = jwtTokenProvider.createAccessToken(Map.of("memberId", member.getId()));
-		String requestBody = "{\"productId\": 1,\"message\": {\"senderId\": 1,\"content\": \"얼마야?\"}}";
+		Member sender = FixtureFactory.createAnotherMember();
+		memberRepository.save(sender);
+		String accessToken = jwtTokenProvider.createAccessToken(Map.of("memberId", sender.getId()));
+		String requestBody = "{\"productId\": 1,\"message\": {\"senderId\": " + sender.getId()
+			+ ",\"content\": \"얼마야?\"}}";
 
 		//when
 		ResultActions resultActions = mockMvc.perform(
@@ -69,5 +72,34 @@ public class ChatTest {
 		resultActions
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.roomId").isNotEmpty());
+	}
+
+	@Test
+	@DisplayName("채팅방을 만들려할 때 구매자 아이디와 메세지 전송자 아이디가 같지 않으면 예외를 던진다.")
+	void createChatRoomWithNotSameBuyerIdAndSenderId() throws Exception {
+		//given
+		Member member = FixtureFactory.createMember();
+		memberRepository.save(member);
+		Product product = FixtureFactory.createProductRequest(member);
+		productRepository.save(product);
+		Member sender = FixtureFactory.createAnotherMember();
+		memberRepository.save(sender);
+		String accessToken = jwtTokenProvider.createAccessToken(Map.of("memberId", sender.getId()));
+		String requestBody = "{\"productId\": 1,\"message\": {\"senderId\": " + (sender.getId() + 1)
+			+ ",\"content\": \"얼마야?\"}}";
+
+		//when
+		ResultActions resultActions = mockMvc.perform(
+				MockMvcRequestBuilders
+					.post("/api/chat/room")
+					.header("Authorization", "Bearer " + accessToken)
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(requestBody)
+			)
+			.andDo(print());
+
+		//given
+		resultActions
+			.andExpect(status().isBadRequest());
 	}
 }

--- a/be/src/test/java/team05a/secondhand/chat/integration/ChatTest.java
+++ b/be/src/test/java/team05a/secondhand/chat/integration/ChatTest.java
@@ -154,8 +154,7 @@ public class ChatTest {
 		Member buyer = FixtureFactory.createAnotherMember();
 		memberRepository.save(buyer);
 		ChatRoom chatRoom = ChatRoom.builder()
-			.uuid("uuid")
-			.member(buyer)
+			.buyer(buyer)
 			.product(product)
 			.build();
 		chatRoomRepository.save(chatRoom);

--- a/be/src/test/java/team05a/secondhand/chat/integration/ChatTest.java
+++ b/be/src/test/java/team05a/secondhand/chat/integration/ChatTest.java
@@ -1,6 +1,7 @@
 package team05a.secondhand.chat.integration;
 
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.util.Map;
 
@@ -14,8 +15,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import team05a.secondhand.DatabaseCleanup;
 import team05a.secondhand.fixture.FixtureFactory;
@@ -38,8 +37,6 @@ public class ChatTest {
 	@Autowired
 	private JwtTokenProvider jwtTokenProvider;
 	@Autowired
-	private ObjectMapper objectMapper;
-	@Autowired
 	private DatabaseCleanup databaseCleanup;
 
 	@BeforeEach
@@ -50,6 +47,7 @@ public class ChatTest {
 	@Test
 	@DisplayName("채팅방을 만든다.")
 	void createChatRoom() throws Exception {
+		//given
 		Member member = FixtureFactory.createMember();
 		memberRepository.save(member);
 		Product product = FixtureFactory.createProductRequest(member);
@@ -57,6 +55,7 @@ public class ChatTest {
 		String accessToken = jwtTokenProvider.createAccessToken(Map.of("memberId", member.getId()));
 		String requestBody = "{\"productId\": 1,\"message\": {\"senderId\": 1,\"content\": \"얼마야?\"}}";
 
+		//when
 		ResultActions resultActions = mockMvc.perform(
 				MockMvcRequestBuilders
 					.post("/api/chat/room")
@@ -66,5 +65,9 @@ public class ChatTest {
 			)
 			.andDo(print());
 
+		//then
+		resultActions
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.roomId").isNotEmpty());
 	}
 }

--- a/be/src/test/java/team05a/secondhand/chat/integration/ChatTest.java
+++ b/be/src/test/java/team05a/secondhand/chat/integration/ChatTest.java
@@ -17,6 +17,8 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import team05a.secondhand.DatabaseCleanup;
+import team05a.secondhand.errors.exception.BuyerIdAndMessageSenderIdNotSameException;
+import team05a.secondhand.errors.exception.SellerIdAndBuyerIdSameException;
 import team05a.secondhand.fixture.FixtureFactory;
 import team05a.secondhand.jwt.JwtTokenProvider;
 import team05a.secondhand.member.data.entity.Member;
@@ -87,6 +89,7 @@ public class ChatTest {
 		String accessToken = jwtTokenProvider.createAccessToken(Map.of("memberId", sender.getId()));
 		String requestBody = "{\"productId\": 1,\"message\": {\"senderId\": " + (sender.getId() + 1)
 			+ ",\"content\": \"얼마야?\"}}";
+		BuyerIdAndMessageSenderIdNotSameException exception = new BuyerIdAndMessageSenderIdNotSameException();
 
 		//when
 		ResultActions resultActions = mockMvc.perform(
@@ -100,6 +103,38 @@ public class ChatTest {
 
 		//given
 		resultActions
-			.andExpect(status().isBadRequest());
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.message")
+				.value(exception.getMessage()));
+	}
+
+	@Test
+	@DisplayName("채팅방을 만들려할 때 구매자 아이디와 판매자 아이디가 같으면 예외를 던진다.")
+	void createChatRoomWithNotSameBuyerIdAndSellerId() throws Exception {
+		//given
+		Member member = FixtureFactory.createMember();
+		memberRepository.save(member);
+		Product product = FixtureFactory.createProductRequest(member);
+		productRepository.save(product);
+		String accessToken = jwtTokenProvider.createAccessToken(Map.of("memberId", member.getId()));
+		String requestBody = "{\"productId\": 1,\"message\": {\"senderId\": " + member.getId()
+			+ ",\"content\": \"얼마야?\"}}";
+		SellerIdAndBuyerIdSameException exception = new SellerIdAndBuyerIdSameException();
+
+		//when
+		ResultActions resultActions = mockMvc.perform(
+				MockMvcRequestBuilders
+					.post("/api/chat/room")
+					.header("Authorization", "Bearer " + accessToken)
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(requestBody)
+			)
+			.andDo(print());
+
+		//given
+		resultActions
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.message")
+				.value(exception.getMessage()));
 	}
 }


### PR DESCRIPTION
## 구현 기능
 - 구매자 아이디와 상품 아이디를 가지는 채팅방이 존재하는 지 확인, 있으면 예외를 던짐
 - 구매자 아이디와 첫 메세지 전송자 아이디가 동일한지 확인, 다르면 예외를 던짐
 - 구매자 아이디와 상품 판매자 아이디가 다른 지 확인, 같으면 예외를 던짐
 - 채팅방을 만들고 db에 저장
 - 처음 채팅 메세지를 db에 저장
 - 채팅방 아이디를 응답으로 반환
## 테스트 케이스
 - 채팅방이 없으면 채팅방을 새로 생성
 - 해당 memberId, productId로 만들어진 채팅방이 있으면 예외를 던짐
 - request의 구매자 아이디와 첫 메세지 전송자 아이디가 동일 하지 않으면 예외를 던짐
 - request의 구매자 아이디와 상품의 판매자 아이디가 동일하면 예외를 던짐