### PR TITLE
[BE] 채팅방 나가기 및 목록 조회 리팩토링

### DIFF
--- a/be/src/main/java/team05a/secondhand/chat/data/entity/ChatRoom.java
+++ b/be/src/main/java/team05a/secondhand/chat/data/entity/ChatRoom.java
@@ -57,4 +57,12 @@ public class ChatRoom {
 	public void deleteBuyer() {
 		this.buyer = null;
 	}
+
+	public void updateBuyerLastReadMessageId(Long messageId) {
+		this.buyerLastReadMessageId = messageId;
+	}
+
+	public void updateSellerLastReadMessageId(Long messageId) {
+		this.sellerLastReadMessageId = messageId;
+	}
 }

--- a/be/src/main/java/team05a/secondhand/chat/repository/ChatRoomRepository.java
+++ b/be/src/main/java/team05a/secondhand/chat/repository/ChatRoomRepository.java
@@ -12,7 +12,7 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long>, ChatR
 
 	Optional<ChatRoom> findByBuyerIdAndProductId(Long buyerId, Long productId);
 
-	ChatRoom findByUuid(String uuid);
+	Optional<ChatRoom> findByUuid(String uuid);
 
 	Long countByProductId(Long productId);
 }

--- a/be/src/main/java/team05a/secondhand/chat/repository/ChatRoomRepositoryImpl.java
+++ b/be/src/main/java/team05a/secondhand/chat/repository/ChatRoomRepositoryImpl.java
@@ -27,7 +27,7 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryCustom {
 		List<ChatRoom> chatRoomList = jpaQueryFactory
 			.selectFrom(chatRoom)
 			.where(
-				chatRoom.product.member.id.eq(memberId).or(
+				chatRoom.seller.id.eq(memberId).or(
 					chatRoom.buyer.id.eq(memberId)),
 				eqProductId(productId)
 			)

--- a/be/src/main/java/team05a/secondhand/chat/repository/MessageRepositoryImpl.java
+++ b/be/src/main/java/team05a/secondhand/chat/repository/MessageRepositoryImpl.java
@@ -48,7 +48,7 @@ public class MessageRepositoryImpl implements MessageRepositoryCustom {
 				.execute();
 			return room.getBuyerLastReadMessageId() == null ? 0L : room.getBuyerLastReadMessageId();
 		}
-		if (memberId.equals(room.getProduct().getMember().getId())) {
+		if (memberId.equals(room.getSeller().getId())) {
 			jpaQueryFactory.update(chatRoom)
 				.set(chatRoom.sellerLastReadMessageId, messageId)
 				.where(chatRoom.id.eq(room.getId()))

--- a/be/src/main/java/team05a/secondhand/errors/exception/ChatRoomNotFoundException.java
+++ b/be/src/main/java/team05a/secondhand/errors/exception/ChatRoomNotFoundException.java
@@ -1,0 +1,10 @@
+package team05a.secondhand.errors.exception;
+
+public class ChatRoomNotFoundException extends RuntimeException {
+
+	private static final String MESSAGE = "채팅방을 찾을 수 없습니다.";
+
+	public ChatRoomNotFoundException() {
+		super(MESSAGE);
+	}
+}

--- a/be/src/main/java/team05a/secondhand/errors/handler/ChatExceptionHandler.java
+++ b/be/src/main/java/team05a/secondhand/errors/handler/ChatExceptionHandler.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import team05a.secondhand.errors.ErrorResponse;
 import team05a.secondhand.errors.exception.BuyerIdAndMessageSenderIdNotSameException;
 import team05a.secondhand.errors.exception.ChatRoomExistsException;
+import team05a.secondhand.errors.exception.ChatRoomNotFoundException;
 import team05a.secondhand.errors.exception.IllegalChatRoomParticipantException;
 import team05a.secondhand.errors.exception.SellerIdAndBuyerIdSameException;
 
@@ -48,6 +49,15 @@ public class ChatExceptionHandler {
 	public ResponseEntity<ErrorResponse> handleIllegalChatRoomParticipantException(
 		IllegalChatRoomParticipantException e) {
 		log.warn("IllegalChatRoomParticipantException handling : {}", e.toString());
+
+		ErrorResponse response = ErrorResponse.from(HttpStatus.BAD_REQUEST, e.getMessage());
+		return ResponseEntity.status(response.getStatus())
+			.body(response);
+	}
+
+	@ExceptionHandler(ChatRoomNotFoundException.class)
+	public ResponseEntity<ErrorResponse> handleChatRoomNotFoundException(ChatRoomNotFoundException e) {
+		log.warn("ChatRoomNotFoundException handling : {}", e.toString());
 
 		ErrorResponse response = ErrorResponse.from(HttpStatus.BAD_REQUEST, e.getMessage());
 		return ResponseEntity.status(response.getStatus())

--- a/be/src/test/java/team05a/secondhand/fixture/FixtureFactory.java
+++ b/be/src/test/java/team05a/secondhand/fixture/FixtureFactory.java
@@ -268,6 +268,7 @@ public class FixtureFactory {
 	public static ChatRoom createChatRoom(Member buyer, Product product) {
 		return ChatRoom.builder()
 			.buyer(buyer)
+			.seller(product.getMember())
 			.product(product)
 			.build();
 	}


### PR DESCRIPTION
- FixtureFactory의 createChatRoom 메서드에 seller 추가
- 채팅방 목록 조회에서 product->member의 id가 아닌 seller의 id로 조회하도록 변경
- 메세지 저장 시 lastReadMessageId 변경 로직 추가
- chatoom의 findByUuid를 Optional로 변경 후 notFound 에러 처리
- createChatRoom에 savedmessage를 savedMessage로 변경

-> 생각해보니까 seller와 buyer를 null로 만들면 한명만 삭제했을 때 삭제 안한 사람의 채팅방에서 상대방 정보를 못가져오는데 차라리 buyerDeleted와 sellerDeleted 칼럼을 만드는 것이 더 낫다는 생각이 드네용 이러면 삭제를 하고도 그 상품에 대해 채팅방을 다시 만들면 그 채팅방으로 들어가는 식으로 해도 될 것 같아요!! 만약 나중에 refactoring할 때 이부분 이야기해보고 괜찮을 것 같으면 진행하겠습니당

그런데 b팀은 나가기를 하면 바로 채팅방이 삭제되는데 저희는 새로고침을 해야만 사라지는 이유를 모르겠어요ㅠㅠ